### PR TITLE
Remove failed file after success

### DIFF
--- a/bin/diode_receive
+++ b/bin/diode_receive
@@ -158,13 +158,16 @@ def finish_file(packet: dict) -> None:
     """
     Validate that file has been completed and append to finished files
     """
+    failed_path = os.path.join(OUTPUT_DIR, f"{RECEIVE_STATE.file_path}.failed")
     if RECEIVE_STATE.file_path is not None and len(RECEIVE_STATE.known_chunks) != packet['c']:
         DIODE_LOGGER.error("Missing chunks for %s", packet['p'])
         os.remove(os.path.join(OUTPUT_DIR, RECEIVE_STATE.file_path))
-        Path(os.path.join(OUTPUT_DIR, f"{RECEIVE_STATE.file_path}.failed")).touch()
+        Path(failed_path).touch()
         reset_transfer(success=False)
     elif RECEIVE_STATE.file_path is not None:
         DIODE_LOGGER.info("Finished receiving %s", packet['p'])
+        if os.path.exists(failed_path):
+            os.remove(failed_path)
         reset_transfer(success=True)
 
 def reset_transfer(success: bool = True) -> None:


### PR DESCRIPTION
After successfully re-transmitting a failed chunk remove the corresponding .failed file.