### PR TITLE
Add receive buffer and batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,16 @@ of about 0.5 MB/s can be achieved. This is fast enough to keep a mirror of
 OpenBSD with a selected subset of packages up to date in an internal
 network.
 
-Depending on the configured speed, some packets are lost. To avoid having
-to re-transmit large files, which in turn is again error-prone, chunking
-large files before transmitting is possible with the `bin/split_files`
-script. The `bin/merge_files` script can re-assemble the original files
-on the receiving Pi. The scripts use `sha256` to validate the transferred
-files.
+Depending on the configured speed, some packets are lost. If a packet loss
+occured in my tests, then usually dozens packets at a time. To mitigate
+this problem, data chunks are sent in batches of 1000. These batches are
+then resent twice.
+
+To avoid having to re-transmit large files, which in turn is again
+error-prone, chunking large files before transmitting is
+possible with the `bin/split_files` script. The `bin/merge_files` script
+can re-assemble the original files on the receiving Pi. The scripts use
+`sha256` to validate the transferred files.
 
 ## Security
 There are some serious limitations to the concept of the diode and the

--- a/bin/diode_receive
+++ b/bin/diode_receive
@@ -11,6 +11,7 @@ import logging
 import os
 import socket
 import sys
+import traceback
 
 from pathlib import Path
 from logging import handlers
@@ -65,6 +66,8 @@ class ReceiveState:
         self.path_hash = None
         self.prev_chunk = -1
         self.missed_chunks = set()
+        self.buffer = {}
+        self.failed = False
 
     def add_bytes(self, chunk_kbytes: int):
         """
@@ -82,12 +85,32 @@ class ReceiveState:
         self.path_hash = path_hash
         self.file_size = file_size
 
-RECEIVE_STATE = ReceiveState()
+    def buffer_packet(self, packet: dict):
+        """
+        Buffer packets, in total about 10M of data. That should ensure
+        that only partially received 10M files can be completed in the second
+        run.
+        """
+        if len(self.buffer) > 1000:
+            raise ValueError(
+                f"Buffer too long, probably missed packet. Last chunk: {self.prev_chunk}"
+                f", next buffered package: {sorted(self.buffer.items())[0][0]}",
+            )
+        self.buffer[packet['c']] = packet
 
-sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-sock.bind((BIND_IP, BIND_PORT))
+    def get_buffered_packets(self):
+        """
+        Get currently buffered packets as long as no packet is missing.
+        """
+        packets = sorted(self.buffer.items())
+        prev_chunk = self.prev_chunk
+        for count, packet in packets:
+            if count == prev_chunk + 1:
+                prev_chunk += 1
+                del self.buffer[count]
+                yield packet
+            else:
+                break
 
 class Display:
     """
@@ -126,15 +149,16 @@ class Display:
         self.arduino.write(bytes(line1+'\n', 'ascii'))
         self.arduino.write(bytes(line2+'\n', 'ascii'))
 
-def write_chunk_to_file(path: str, chunk: bytes) -> None:
+def write_chunk_to_file(path: str, packet: dict) -> None:
     """
     Write validated chunk to file
     """
+    data = bytes.fromhex(packet['d'])
     full_path = os.path.join(OUTPUT_DIR, path)
     os.makedirs(os.path.dirname(full_path), exist_ok=True)
     with open(full_path, 'ab') as f:
-        f.write(chunk)
-        RECEIVE_STATE.add_bytes(len(chunk))
+        f.write(data)
+        RECEIVE_STATE.add_bytes(len(data))
 
 def new_file(path: str, size: int, path_hash: str) -> None:
     """
@@ -191,23 +215,25 @@ def listen() -> None:
         try:
             data, _ = sock.recvfrom(4096)
             packet = json.loads(data.decode())
-            if packet["t"] == PKG_TYPE_DATA:
+            if packet["t"] == PKG_TYPE_DATA and RECEIVE_STATE.file_path:
                 process_chunk(packet)
             elif packet["t"] == PKG_TYPE_START:
                 new_file(packet["p"], packet["s"], packet["h"])
-            elif packet["t"] == PKG_TYPE_END:
+            elif packet["t"] == PKG_TYPE_END and RECEIVE_STATE.file_path:
                 finish_file(packet)
-            else:
+            elif RECEIVE_STATE.file_path:
                 raise ValueError("Unknown packet type")
         except Exception as e:  # pylint: disable=broad-exception-caught
             DIODE_LOGGER.error(e)
+            print(traceback.format_exc())
             reset_transfer(success=False)
 
-def chunk_is_valid(packet: dict, chunk_bytes: bytes) -> bool:
+def is_chunk_valid(packet: dict) -> bool:
     """
     Check if chunk is valid
     """
     result = True
+    chunk_bytes = bytes.fromhex(packet['d'])
     if not packet['h'] != RECEIVE_STATE.path_hash:
         DIODE_LOGGER.warning("Path does not match in %s", packet['c'])
         result = False
@@ -216,25 +242,33 @@ def chunk_is_valid(packet: dict, chunk_bytes: bytes) -> bool:
         result = False
     if packet['c'] in RECEIVE_STATE.known_chunks:
         result = False
-    elif packet['c'] != RECEIVE_STATE.prev_chunk + 1:
-        missed_chunk = RECEIVE_STATE.prev_chunk + 1
-        if missed_chunk not in RECEIVE_STATE.missed_chunks:
-            DIODE_LOGGER.error("Missed chunk %s", missed_chunk)
-            RECEIVE_STATE.missed_chunks.add(missed_chunk)
-        result = False
     return result
 
 def process_chunk(packet: dict) -> None:
     """
     Process data paket
     """
-    chunk_bytes = bytes.fromhex(packet['d'])
-    if chunk_is_valid(packet, chunk_bytes):
-        RECEIVE_STATE.prev_chunk = packet['c']
-        write_chunk_to_file(RECEIVE_STATE.file_path, chunk_bytes)
-        RECEIVE_STATE.known_chunks.add(packet['c'])
-        if DISPLAY is not None and packet['c'] % 1000 == 0:
+    if is_chunk_valid(packet) and not RECEIVE_STATE.failed:
+        try:
+            RECEIVE_STATE.buffer_packet(packet)
+        except ValueError as exc:
+            DIODE_LOGGER.error("Aborting transfer due to %s", exc)
+            RECEIVE_STATE.failed = True
+    for buffered_packet in RECEIVE_STATE.get_buffered_packets():
+        if buffered_packet['c'] != RECEIVE_STATE.prev_chunk + 1:
+            DIODE_LOGGER.error("Wrong packet order.")
+        write_chunk_to_file(RECEIVE_STATE.file_path, buffered_packet)
+        RECEIVE_STATE.known_chunks.add(buffered_packet['c'])
+        RECEIVE_STATE.prev_chunk = buffered_packet['c']
+        if DISPLAY is not None and buffered_packet['c'] % 1000 == 0:
             DISPLAY.update()
+
+RECEIVE_STATE = ReceiveState()
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+sock.bind((BIND_IP, BIND_PORT))
 
 DISPLAY = Display(ARGS.arduino) if ARGS.arduino else None
 

--- a/bin/diode_send
+++ b/bin/diode_send
@@ -7,6 +7,7 @@ import argparse
 import hashlib
 import json
 import logging
+import math
 import os
 import socket
 import time
@@ -36,12 +37,13 @@ PARSER.add_argument('--directory', type=str, nargs='?', required=True,
 ARGS = PARSER.parse_args()
 
 
-CHUNK_SIZE = 512
+CHUNK_SIZE = 640
 TARGET_IP = ARGS.target_subnet
 TARGET_PORT = int(ARGS.target_port)
 SOURCE_DIR = ARGS.directory
-RATE_LIMIT_DELAY_CYCLES = 10000
-RESEND_PACKET = 1
+DELAY_NEXT_CHUNK = 4000
+BATCH_SIZE = 1000
+RESEND_PACKET = 3
 SCAN_INTERVAL = 1
 STABILITY_CHECK_DELAY = 1
 
@@ -52,23 +54,27 @@ PKG_TYPE_END = 2
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
 
-def busy_wait_sleep():
+def busy_wait_sleep(cycles: int = DELAY_NEXT_CHUNK):
     """
     time.sleep() is too slow (on OpenBSD). Looping through
     a range can introduce "arbitrarily" short delays. Can be
     replaced by any other function that can introduce delays in
     the range of microseconds.
     """
-    for n in range(0, RATE_LIMIT_DELAY_CYCLES):
+    for n in range(0, cycles):
         i = n
 
-def get_chunks(filepath: str):
+def get_chunks(filepath: str, batch):
     """
     Read file chunks
     """
     with open(filepath, 'rb') as f:
-        while chunk := f.read(CHUNK_SIZE):
-            yield chunk
+        f.seek(batch*CHUNK_SIZE)
+        for _ in range(BATCH_SIZE):
+            data = f.read(CHUNK_SIZE)
+            if not data:
+                break  # End of file
+            yield data
 
 def send_start_paket(filepath: str, rel_path: str, rel_path_hash: str) -> None:
     """
@@ -84,6 +90,7 @@ def send_start_paket(filepath: str, rel_path: str, rel_path_hash: str) -> None:
     }).encode()
     for n in range(0, RESEND_PACKET):  # pylint: disable=unused-variable
         sock.sendto(start_packet, (TARGET_IP, TARGET_PORT))
+        busy_wait_sleep(DELAY_NEXT_CHUNK)
 
 def send_end_paket(filepath: str, rel_path: str, count: int) -> None:
     """
@@ -92,6 +99,7 @@ def send_end_paket(filepath: str, rel_path: str, count: int) -> None:
     end_packet = json.dumps({"p":rel_path, 't': PKG_TYPE_END, 'c': count}).encode()
     for n in range(0, RESEND_PACKET):  # pylint: disable=unused-variable
         sock.sendto(end_packet, (TARGET_IP, TARGET_PORT))
+        busy_wait_sleep(DELAY_NEXT_CHUNK)
     os.remove(filepath)
     DIODE_LOGGER.info("Finished sending file: %s", rel_path)
 
@@ -108,9 +116,16 @@ def send_data_paket(rel_path_hash: str, chunk: bytes, count: int) -> None:
         't': PKG_TYPE_DATA,
     }
     data = json.dumps(packet).encode()
-    for n in range(0, RESEND_PACKET):  # pylint: disable=unused-variable
-        sock.sendto(data, (TARGET_IP, TARGET_PORT))
-        busy_wait_sleep()
+    sock.sendto(data, (TARGET_IP, TARGET_PORT))
+    busy_wait_sleep(DELAY_NEXT_CHUNK)
+
+def calculate_number_of_batches(filepath):
+    """
+    Calculate the number of batches. We want to send BATCH_SIZE packets
+    in one batch.
+    """
+    filesize = os.path.getsize(filepath)
+    return math.ceil(filesize/CHUNK_SIZE/BATCH_SIZE)
 
 def send_file_chunks(filepath: str, rel_path: str) -> None:
     """
@@ -120,11 +135,18 @@ def send_file_chunks(filepath: str, rel_path: str) -> None:
     :param rel_path: relative path to file in relation to watched dir
     """
     rel_path_hash = hashlib.md5(rel_path.encode("utf-8")).hexdigest()
+    num_batches = calculate_number_of_batches(filepath)
     send_start_paket(filepath, rel_path, rel_path_hash)
     count = 0
-    for chunk in get_chunks(filepath):
-        send_data_paket(rel_path_hash, chunk, count)
-        count += 1
+    batch_start_count = 0
+    for batch in range(0, num_batches):
+        batch_start_count = count
+        for resend in range(0, RESEND_PACKET):
+            for chunk in get_chunks(filepath, batch):
+                send_data_paket(rel_path_hash, chunk, count)
+                count += 1
+            if resend < RESEND_PACKET - 1:
+                count = batch_start_count
     send_end_paket(filepath, rel_path, count)
 
 def is_file_stable(filepath: str, delay: int = STABILITY_CHECK_DELAY) -> bool:


### PR DESCRIPTION
Send packets in batches of 1000 and buffer them on the receiver. This allows dozens of packets to be lost at a time. The receiver buffers the received packages and writes them to file when the missing chunks are filled in.