### PR TITLE
Replace JSON with fixed length strings, fix #32

### DIFF
--- a/bin/diode_receive
+++ b/bin/diode_receive
@@ -6,7 +6,6 @@ Receive files through unidirectional serial device
 
 import argparse
 import hashlib
-import json
 import logging
 import os
 import socket
@@ -96,7 +95,7 @@ class ReceiveState:
                 f"Buffer too long, probably missed packet. Last chunk: {self.prev_chunk}"
                 f", next buffered package: {sorted(self.buffer.items())[0][0]}",
             )
-        self.buffer[packet['c']] = packet
+        self.buffer[packet['count']] = packet
 
     def get_buffered_packets(self):
         """
@@ -153,7 +152,7 @@ def write_chunk_to_file(path: str, packet: dict) -> None:
     """
     Write validated chunk to file
     """
-    data = bytes.fromhex(packet['d'])
+    data = bytes.fromhex(packet['data'])
     full_path = os.path.join(OUTPUT_DIR, path)
     os.makedirs(os.path.dirname(full_path), exist_ok=True)
     with open(full_path, 'ab') as f:
@@ -184,12 +183,12 @@ def is_file_valid(packet: dict) -> bool:
     """
     success = True
     filesize = os.path.getsize(os.path.join(OUTPUT_DIR, RECEIVE_STATE.file_path))
-    if  len(RECEIVE_STATE.known_chunks) != packet['c']:
+    if len(RECEIVE_STATE.known_chunks) != packet['count']:
         DIODE_LOGGER.error(
             "Missing chunks for %s. Received %s but expected %s.",
             packet['p'],
             len(RECEIVE_STATE.known_chunks),
-            packet['c']
+            packet['count']
         )
         success = False
     if RECEIVE_STATE.file_size != filesize:
@@ -208,7 +207,7 @@ def finish_file(packet: dict) -> None:
     """
     failed_path = os.path.join(OUTPUT_DIR, f"{RECEIVE_STATE.file_path}.failed")
     if is_file_valid(packet):
-        DIODE_LOGGER.info("Finished receiving %s", packet['p'])
+        DIODE_LOGGER.info("Finished receiving %s", packet['data'])
         if os.path.exists(failed_path):
             os.remove(failed_path)
         reset_transfer(success=True)
@@ -237,12 +236,12 @@ def listen() -> None:
     while True:
         try:
             data, _ = sock.recvfrom(4096)
-            packet = json.loads(data.decode())
-            if packet["t"] == PKG_TYPE_DATA and RECEIVE_STATE.file_path:
+            packet = decode_package(data)
+            if packet["type"] == PKG_TYPE_DATA and RECEIVE_STATE.file_path:
                 process_chunk(packet)
-            elif packet["t"] == PKG_TYPE_START:
-                new_file(packet["p"], packet["s"], packet["h"])
-            elif packet["t"] == PKG_TYPE_END and RECEIVE_STATE.file_path:
+            elif packet["type"] == PKG_TYPE_START:
+                new_file(packet["data"], packet["count"], packet["path_hash"])
+            elif packet["type"] == PKG_TYPE_END and RECEIVE_STATE.file_path:
                 finish_file(packet)
             elif RECEIVE_STATE.file_path:
                 raise ValueError("Unknown packet type")
@@ -256,16 +255,38 @@ def is_chunk_valid(packet: dict) -> bool:
     Check if chunk is valid
     """
     result = True
-    chunk_bytes = bytes.fromhex(packet['d'])
-    if not packet['h'] != RECEIVE_STATE.path_hash:
-        DIODE_LOGGER.warning("Path does not match in %s", packet['c'])
+    chunk_bytes = bytes.fromhex(packet['data'])
+    if packet['path_hash'] != RECEIVE_STATE.path_hash:
+        DIODE_LOGGER.warning("Path does not match in %s", packet['count'])
         result = False
-    if hashlib.md5(chunk_bytes).hexdigest() != packet['h']:
-        DIODE_LOGGER.warning("Hash does not match in %s", packet['c'])
+    if hashlib.md5(chunk_bytes).hexdigest() != packet['data_hash']:
+        DIODE_LOGGER.warning("Hash does not match in %s", packet['count'])
         result = False
-    if packet['c'] in RECEIVE_STATE.known_chunks:
+    if packet['count'] in RECEIVE_STATE.known_chunks:
         result = False
     return result
+
+def decode_package(package: bytes):
+    """
+    Decode package with fixed length substrings. The input data is not validated. The hases must have a length
+    of 32 chars, the count/filesize must not bef longer than 10 chars. The type is only one char.
+
+    package format:
+        package_type                              = string[0:1]
+        count(data/end pkg) / filesize(start pkg) = string[1:11]
+        path_hash                                 = string[11:43]
+        data_hash                                 = string[43:75]
+        data(data pkg) / path(start/end pkg)      = string[75:]
+    """
+    package_string = package.decode()
+    data = {
+        "type": int(package_string[0:1]),
+        "count": int(package_string[1:11]),
+        "path_hash": package_string[11:43],
+        "data_hash": package_string[43:75],
+        "data": package_string[75:]
+    }
+    return data
 
 def process_chunk(packet: dict) -> None:
     """
@@ -278,12 +299,12 @@ def process_chunk(packet: dict) -> None:
             DIODE_LOGGER.error("Aborting transfer due to %s", exc)
             RECEIVE_STATE.failed = True
     for buffered_packet in RECEIVE_STATE.get_buffered_packets():
-        if buffered_packet['c'] != RECEIVE_STATE.prev_chunk + 1:
+        if buffered_packet['count'] != RECEIVE_STATE.prev_chunk + 1:
             DIODE_LOGGER.error("Wrong packet order.")
         write_chunk_to_file(RECEIVE_STATE.file_path, buffered_packet)
-        RECEIVE_STATE.known_chunks.add(buffered_packet['c'])
-        RECEIVE_STATE.prev_chunk = buffered_packet['c']
-        if DISPLAY is not None and buffered_packet['c'] % 1000 == 0:
+        RECEIVE_STATE.known_chunks.add(buffered_packet['count'])
+        RECEIVE_STATE.prev_chunk = buffered_packet['count']
+        if DISPLAY is not None and buffered_packet['count'] % 1000 == 0:
             DISPLAY.update()
 
 RECEIVE_STATE = ReceiveState()

--- a/bin/diode_send
+++ b/bin/diode_send
@@ -5,7 +5,6 @@ Send files through unidirectional serial device
 
 import argparse
 import hashlib
-import json
 import logging
 import math
 import os
@@ -76,18 +75,33 @@ def get_chunks(filepath: str, batch):
                 break
             yield data
 
+def encode_package(pkg_type: int, count_or_filesize: int, rel_path_hash: str, data_hash: str, data_or_path: str):
+    """
+    Create package with fixed length substrings. The input data is not validated. The hases must have a length
+    of 32 chars, the count/filesize must not bef longer than 10 chars. The type is only one char.
+
+    package format:
+        package_type                              = string[0:1]
+        count(data/end pkg) / filesize(start pkg) = string[1:11]
+        path_hash                                 = string[11:43]
+        data_hash                                 = string[43:75]
+        data(data pkg) / path(start/end pkg)      = string[75:]
+
+    :param pkg_type: integer with length one which indicates the package type.
+    :param count_or_filesize: the filesize in the start package or the package count for data packages. Max 10 chars in length.
+    :param rel_path_hash: md5sum of rel path
+    :param data_hash: md5sum of data
+    :param data_or_path: the relative path of the file in the start package or a file chunk for data packages.
+    """
+    return f"{pkg_type}{count_or_filesize:010}{rel_path_hash}{data_hash}{data_or_path}".encode()
+
 def send_start_paket(filepath: str, rel_path: str, rel_path_hash: str) -> None:
     """
     Send first paket with meta data
     """
     DIODE_LOGGER.info("Sending file: %s", rel_path)
     filesize = os.path.getsize(filepath)
-    start_packet = json.dumps({
-        'p': rel_path,
-        's': filesize,
-        't': PKG_TYPE_START,
-        'h': rel_path_hash
-    }).encode()
+    start_packet = encode_package(PKG_TYPE_START, filesize, rel_path_hash, "00000000000000000000000000000000", rel_path)
     for n in range(0, RESEND_PACKET):  # pylint: disable=unused-variable
         sock.sendto(start_packet, (TARGET_IP, TARGET_PORT))
         busy_wait_sleep(DELAY_NEXT_CHUNK)
@@ -96,7 +110,7 @@ def send_end_paket(filepath: str, rel_path: str, count: int) -> None:
     """
     Send last paket with final count
     """
-    end_packet = json.dumps({"p":rel_path, 't': PKG_TYPE_END, 'c': count}).encode()
+    end_packet = encode_package(PKG_TYPE_END, count, "00000000000000000000000000000000", "00000000000000000000000000000000", rel_path)
     for n in range(0, RESEND_PACKET):  # pylint: disable=unused-variable
         sock.sendto(end_packet, (TARGET_IP, TARGET_PORT))
         busy_wait_sleep(DELAY_NEXT_CHUNK)
@@ -107,16 +121,9 @@ def send_data_paket(rel_path_hash: str, chunk: bytes, count: int) -> None:
     """
     Send data paket
     """
-    hash_digest = hashlib.md5(chunk).hexdigest()
-    packet = {
-        'c': count,
-        'p': rel_path_hash,
-        'h': hash_digest,
-        'd': chunk.hex(),
-        't': PKG_TYPE_DATA,
-    }
-    data = json.dumps(packet).encode()
-    sock.sendto(data, (TARGET_IP, TARGET_PORT))
+    data_hash = hashlib.md5(chunk).hexdigest()
+    data_packet = encode_package(PKG_TYPE_DATA, count, rel_path_hash, data_hash, chunk.hex())
+    sock.sendto(data_packet, (TARGET_IP, TARGET_PORT))
     busy_wait_sleep(DELAY_NEXT_CHUNK)
 
 def calculate_number_of_batches(filepath):


### PR DESCRIPTION
Instead of serializing and unserializing JSON files, this PR introduces fixed length strings as packages. This should improve package handling performance by a factor of 10 (see #32).