### PR TITLE
Add flexible UDP pkg size

### DIFF
--- a/bin/diode_receive
+++ b/bin/diode_receive
@@ -245,7 +245,8 @@ def worker() -> None:
     """
     while True:
         try:
-            packet = decode_package(SOCKET_PKG_QUEUE.get())
+            raw_packet = SOCKET_PKG_QUEUE.get()
+            packet = decode_package(raw_packet)
             if packet["type"] == PKG_TYPE_DATA and RECEIVE_STATE.file_path:
                 process_chunk(packet)
             elif packet["type"] == PKG_TYPE_START:
@@ -253,21 +254,23 @@ def worker() -> None:
             elif packet["type"] == PKG_TYPE_END and RECEIVE_STATE.file_path:
                 finish_file(packet)
             elif packet["type"] == PKG_TYPE_UDP and ARGS.udp_target_port:
-                FORWARD_UDP_QUEUE.put((bytes.fromhex(packet['data']), packet['count']))
+                FORWARD_UDP_QUEUE.put((bytes.fromhex(packet['data']), int(packet['count']), int(packet['path_hash'])))
             elif RECEIVE_STATE.file_path:
                 raise ValueError("Unknown packet type")
         except Exception as e:  # pylint: disable=broad-exception-caught
             DIODE_LOGGER.error(e)
-            print(traceback.format_exc())
+            DIODE_LOGGER.error(traceback.format_exc())
             reset_transfer(success=False)
 
 def listen() -> None:
     """
     Fetch packages from socket queue and throw into worker threading queue
     """
+    bytes_received = 0
     while True:
-        data, _ = sock.recvfrom(4096)
+        data, _ = sock.recvfrom(65535)
         SOCKET_PKG_QUEUE.put(data)
+        bytes_received += len(data)
 
 def is_chunk_valid(packet: dict) -> bool:
     """
@@ -328,13 +331,28 @@ def process_chunk(packet: dict) -> None:
 
 def forward_udp_packets():
     """
-    Forward the content of a UDP packet through the diode.
+    Re-assemble previous full datagram and send to target.
     """
     udp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     DIODE_LOGGER.info("Forwarding UDP packets to %s:%i", ARGS.udp_target_ip, ARGS.udp_target_port)
+    previous_count = 0
+    full_packet = bytes()
+    bytes_processed = 0
+    bytes_sent = 0
     while True:
-        data_packet = FORWARD_UDP_QUEUE.get()
-        udp_sock.sendto(data_packet, (ARGS.udp_target_ip, ARGS.udp_target_port))
+        data_packet, count, packet_size = FORWARD_UDP_QUEUE.get()
+        bytes_processed += len(data_packet)
+        if count == 0:
+            full_packet = data_packet
+            previous_count = 0
+        elif count == previous_count + 1:
+            full_packet = full_packet + data_packet
+            previous_count = count
+        if len(full_packet) == packet_size:
+            udp_sock.sendto(full_packet, (ARGS.udp_target_ip, ARGS.udp_target_port))
+            bytes_sent += len(data_packet)
+            previous_count = 0
+            full_packet = bytes()
 
 RECEIVE_STATE = ReceiveState()
 

--- a/bin/diode_send
+++ b/bin/diode_send
@@ -59,7 +59,7 @@ PKG_TYPE_UDP = 4
 
 EMPTY_HASH = "00000000000000000000000000000000"
 
-UDP_FWD_QUEUE = queue.SimpleQueue()
+UDP_FWD_QUEUE = queue.Queue()
 
 sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
@@ -227,14 +227,19 @@ def receive_udp() -> None:
     while True:
         data, ancdata, flags, addr = udp_sock.recvmsg(65535)
         UDP_FWD_QUEUE.put(data)
+        bytes_received += len(data)
 
 def forward_udp() -> None:
+    bytes_forwarded = 0
     while True:
         data = UDP_FWD_QUEUE.get()
+        count = 0
         for i in range(0, len(data), CHUNK_SIZE):
             chunk = data[i:i+CHUNK_SIZE]
-            data_packet = encode_package(PKG_TYPE_UDP, i, f'{len("data"):032}', EMPTY_HASH, chunk.hex())
+            data_packet = encode_package(PKG_TYPE_UDP, count, f'{len(data):032}', EMPTY_HASH, chunk.hex())
             sock.sendto(data_packet, (TARGET_IP, TARGET_PORT))
+            count += 1
+            bytes_forwarded += len(chunk)
 
 if __name__ == "__main__":
     threading.Thread(target=send_data_wrapper).start()


### PR DESCRIPTION
- The first commit fixes the packet drop issue
- the second commit reassembles the full original packet

```
cat loremipsum.txt | pv -L 700000 | nc -u 127.0.0.1 25500
2,47MiB 0:00:05 [ 689KiB/s] [                  <=>                                                                                               
```
Transmitting 2.5 MB of lorem ipsum with 689KiB/s works without issues, at around 1MB/s some packets are lost. Thats roughly the same speed as the file transfer.